### PR TITLE
show nfts during load process + progress info

### DIFF
--- a/src/components/Content/Main.js
+++ b/src/components/Content/Main.js
@@ -10,6 +10,7 @@ import logo from '../../img/logo2.PNG'
 const Main = () => {
   const collectionCtx = useContext(CollectionContext);
   const marketplaceCtx = useContext(MarketplaceContext);
+  const collectionLoaded = collectionCtx.collection.length === parseInt(collectionCtx.totalSupply)
   
   return(
     <div className="container-fluid mt-2">
@@ -23,7 +24,13 @@ const Main = () => {
         </main>
       </div>
       <hr/>
-      {!marketplaceCtx.mktIsLoading && <NFTCollection />}
+      {!collectionLoaded && 
+        <div className="d-flex align-items-center justify-content-center">
+          <div className="spinner-border mr-5 pr-5" role="status" aria-hidden="true"></div>
+          <strong>&nbsp;Buscando en el mercado de NFTs...{collectionCtx.collection.length}/{collectionCtx.totalSupply}</strong>
+        </div>
+      }
+      {!marketplaceCtx.mktIsLoading && <NFTCollection showImages={collectionLoaded} />}
       {marketplaceCtx.mktIsLoading && <Spinner />}
     </div>
   );

--- a/src/components/Content/NFTCollection/NFTCollection.js
+++ b/src/components/Content/NFTCollection/NFTCollection.js
@@ -7,7 +7,9 @@ import MarketplaceContext from '../../../store/marketplace-context';
 import { formatPrice } from '../../../helpers/utils';
 import eth from '../../../img/bnb.png';
 
-const NFTCollection = () => {
+const nftURL = (nft) => `https://ipfs.infura.io/ipfs/${nft.img}`
+
+const NFTCollection = ({ showImages = true }) => {
   const web3Ctx = useContext(Web3Context);
   const collectionCtx = useContext(CollectionContext);
   const marketplaceCtx = useContext(MarketplaceContext);
@@ -78,12 +80,13 @@ const NFTCollection = () => {
                 
                 <p className="">{NFT.description}</p>
               </div>
-              {NFT.filetype === "Imagen" ?
-              <img src={`https://ipfs.infura.io/ipfs/${NFT.img}`} className="card-img-bottom" alt={`${NFT.title}`} width="100%" /> 
-              :
-              <video width="100%" autoPlay loop muted>
-                        <source src={`https://ipfs.infura.io/ipfs/${NFT.img}`} type="video/mp4"/>
-                      </video> 
+              {showImages && NFT.filetype === "Imagen" &&
+                <img src={nftURL(NFT)} className="card-img-bottom" alt={`${NFT.title}`} width="100%" /> 
+              }
+              {showImages && NFT.filetype === "MP4" &&
+                <video width="100%" autoPlay loop muted>
+                  <source src={nftURL(NFT)} type="video/mp4"/>
+                </video> 
               }
               <label>Propietario:</label>
               <p className="fw-light fs-6"> {`${owner.substr(0,7)}...${owner.substr(owner.length - 7)}`}</p>

--- a/src/store/CollectionProvider.js
+++ b/src/store/CollectionProvider.js
@@ -119,11 +119,12 @@ const CollectionProvider = props => {
           video: metadata.properties.video.description,
           owner: owner
         }, ...collection];
+        dispatchCollectionAction({type: 'LOADCOLLECTION', collection: collection});
       }catch {
         console.error('Something went wrong');
       }
     }
-    dispatchCollectionAction({type: 'LOADCOLLECTION', collection: collection});     
+    // dispatchCollectionAction({type: 'LOADCOLLECTION', collection: collection});     
   };
 
   const updateCollectionHandler = async(contract, id, owner) => {


### PR DESCRIPTION
He modificado la carga para que se actualice la colección de nfts cada vez que se obtiene la información de uno de ellos. De esta manera se refresca la aplicación con cada elemento nuevo, y los muestra (y no queda la pantalla vacía hasta el final).
Esto provocaba pedir la imagen/video de cada NFT en cada refresco, y la solución más sencilla que he encontrado así desactivar el mostrar la imagen/video hasta que haya terminado la carga (sino el servicio que devuelve las imágenes acaba dando error por "too many requests"). Podría mejorarse el renderizado para que sólo repinte el nuevo elemento, pero hay varios callbacks que no he querido trastear.

Para ayudar a ver cuanto queda mientras se espera, he añadido un mensaje con un spinner, que muestra el número de nfts cargados sobre el total.

Ale, que poquito a poquito va cogiendo cuerpo 😄 